### PR TITLE
Add MeterRatio meter implementation

### DIFF
--- a/Bluewire.Metrics.Specialised.UnitTests/Bluewire.Metrics.Specialised.UnitTests.csproj
+++ b/Bluewire.Metrics.Specialised.UnitTests/Bluewire.Metrics.Specialised.UnitTests.csproj
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3536AF7A-9B0A-4123-B5D2-BA582E6A3DC8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Bluewire.Metrics.Specialised.UnitTests</RootNamespace>
+    <AssemblyName>Bluewire.Metrics.Specialised.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Metrics, Version=0.3.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Metrics.NET.0.3.7\lib\net45\Metrics.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MockClock.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Bluewire.Metrics.Specialised\Bluewire.Metrics.Specialised.csproj">
+      <Project>{74DDE709-F8E9-4509-94D9-E721B67DC2B4}</Project>
+      <Name>Bluewire.Metrics.Specialised</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Bluewire.Metrics.Specialised.UnitTests/Bluewire.Metrics.Specialised.UnitTests.csproj
+++ b/Bluewire.Metrics.Specialised.UnitTests/Bluewire.Metrics.Specialised.UnitTests.csproj
@@ -50,6 +50,8 @@
   <ItemGroup>
     <Compile Include="MockClock.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="MeterRatioMeterTests.cs" />
+    <Compile Include="RateMeterValueEqualityComparer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Bluewire.Metrics.Specialised.UnitTests/Bluewire.Metrics.Specialised.UnitTests.v3.ncrunchproject
+++ b/Bluewire.Metrics.Specialised.UnitTests/Bluewire.Metrics.Specialised.UnitTests.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/Bluewire.Metrics.Specialised.UnitTests/MeterRatioMeterTests.cs
+++ b/Bluewire.Metrics.Specialised.UnitTests/MeterRatioMeterTests.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Metrics;
+using Metrics.Core;
+using Metrics.MetricData;
+using NUnit.Framework;
+
+namespace Bluewire.Metrics.Specialised.UnitTests
+{
+    [TestFixture]
+    public class MeterRatioMeterTests
+    {
+        class PingContext : IDisposable
+        {
+            private MetricsContext context = Metric.Context(Guid.NewGuid().ToString());
+            public MockClock Clock { get; } = new MockClock();
+            public Meter Numerator { get; }
+            public Meter Denominator { get; }
+            public Meter Ratio { get; }
+
+            public MeterValue RatioValue => ValueReader.GetCurrentValue(Ratio);
+
+            public PingContext()
+            {
+                Numerator = new MeterMetric(Clock, Clock.CreateScheduler());
+                Denominator = new MeterMetric(Clock, Clock.CreateScheduler());
+                Ratio = context.MeterRatioMeter("MeterRatioMeter", "Marks", Numerator, Denominator);
+            }
+
+            public void Dispose()
+            {
+                context?.Dispose();
+                context = null;
+            }
+        }
+
+        [Test]
+        public async Task NumeratorMark_With_NoDenominatorMark_Yields_ValueOfNaN()
+        {
+            var testContext = new PingContext();
+
+            testContext.Numerator.Mark();
+            await testContext.Clock.AdvanceOneMinute();
+
+            Assert.That(
+                testContext.RatioValue,
+                Is.EqualTo(new MeterValue(1, double.NaN, double.NaN, double.NaN, double.NaN, TimeUnit.Seconds, new MeterValue.SetItem[0]))
+                    .Using(new RateMeterValueEqualityComparer()));
+        }
+
+        [Test]
+        public async Task OneNumeratorMark_With_OneDenominatorMark_Yields_ValueOfOne()
+        {
+            var testContext = new PingContext();
+
+            testContext.Numerator.Mark();
+            testContext.Denominator.Mark();
+            await testContext.Clock.AdvanceOneMinute();
+
+            Assert.That(
+                testContext.RatioValue,
+                Is.EqualTo(new MeterValue(1, 1, 1, 1, 1, TimeUnit.Seconds, new MeterValue.SetItem[0]))
+                    .Using(new RateMeterValueEqualityComparer()));
+        }
+
+        [Test]
+        public async Task OneNumeratorMark_With_TwoDenominatorMarks_Yields_ValueOfOneHalf()
+        {
+            var testContext = new PingContext();
+
+            testContext.Numerator.Mark();
+            testContext.Denominator.Mark();
+            testContext.Denominator.Mark();
+            await testContext.Clock.AdvanceOneMinute();
+
+            Assert.That(
+                testContext.RatioValue,
+                Is.EqualTo(new MeterValue(1, 0.5, 0.5, 0.5, 0.5, TimeUnit.Seconds, new MeterValue.SetItem[0]))
+                    .Using(new RateMeterValueEqualityComparer()));
+        }
+
+        [Test]
+        public async Task OneNamedNumeratorMark_With_OneMatchingNamedDenominatorMark_AndOneUnnamedDenominatorMark_Yields_NamedValueOfOne()
+        {
+            var testContext = new PingContext();
+
+            testContext.Numerator.Mark("A");
+            testContext.Denominator.Mark();
+            testContext.Denominator.Mark("A");
+            await testContext.Clock.AdvanceOneMinute();
+
+            var value = testContext.RatioValue.Items.SingleOrDefault(i => i.Item == "A").Value;
+            Assert.That(
+                value,
+                Is.EqualTo(new MeterValue(1, 1, 1, 1, 1, TimeUnit.Seconds, new MeterValue.SetItem[0]))
+                    .Using(new RateMeterValueEqualityComparer()));
+        }
+
+        [Test]
+        public async Task NamedNumeratorMark_With_NoNamedDenominatorMark_Yields_NoValue()
+        {
+            var testContext = new PingContext();
+
+            testContext.Numerator.Mark("A");
+            await testContext.Clock.AdvanceOneMinute();
+
+            var values = testContext.RatioValue.Items.Where(i => i.Item == "A").ToArray();
+            Assert.That(values, Is.Empty, values.FirstOrDefault().Value?.MeanRate.ToString());
+        }
+
+        [Test]
+        public async Task NamedDenominatorMark_With_NoNamedNumeratorMark_Yields_NoValue()
+        {
+            var testContext = new PingContext();
+
+            testContext.Denominator.Mark("A");
+            await testContext.Clock.AdvanceOneMinute();
+
+            var values = testContext.RatioValue.Items.Where(i => i.Item == "A").ToArray();
+            Assert.That(values, Is.Empty, values.FirstOrDefault().Value?.MeanRate.ToString());
+        }
+
+
+        [Test]
+        public void UsageTest()
+        {
+            var context = Metric.Context("Test");
+            var numerator = context.Meter("Numerator", "Pings");
+            var denominator = context.Meter("Denominator", "Pongs");
+            var ratio = context.MeterRatioMeter("MeterRatioMeter", "Pings per Pong", numerator, denominator);
+        }
+    }
+}

--- a/Bluewire.Metrics.Specialised.UnitTests/MockClock.cs
+++ b/Bluewire.Metrics.Specialised.UnitTests/MockClock.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Metrics;
+using Metrics.Utils;
+
+namespace Bluewire.Metrics.Specialised.UnitTests
+{
+    public class MockClock : Clock
+    {
+        private const long NanosecondsPerTick = 1000000 / TimeSpan.TicksPerMillisecond; // ns/ms / t/ms = ns/t
+
+        /// <summary>
+        /// Metrics.NET's 'average over time' is dealt with in terms of minutes. It is useful to have a shortcut for
+        /// advancing the clock by one minute.
+        /// </summary>
+        /// <returns></returns>
+        public async Task AdvanceOneMinute()
+        {
+            await Advance(TimeSpan.FromMinutes(1));
+        }
+
+        public async Task Advance(TimeSpan interval)
+        {
+            var targetNow = now + interval;
+            MockScheduler scheduler;
+            while (TryGetNextScheduler(targetNow, out scheduler))
+            {
+                now = scheduler.NextInvocation;
+                if (!await scheduler.TryRun())
+                {
+                    lock (sync) schedulers.Remove(scheduler);
+                }
+            }
+            now = targetNow;
+        }
+
+        private DateTimeOffset now = DateTimeOffset.Now;
+
+        public override long Nanoseconds => now.Ticks * NanosecondsPerTick; // t * ns/t = ns
+        public override DateTime UTCDateTime => now.UtcDateTime;
+
+        private object sync = new object();
+        private readonly List<MockScheduler> schedulers = new List<MockScheduler>();
+
+        public Scheduler CreateScheduler()
+        {
+            return new MockScheduler(this);
+        }
+
+        private DateTimeOffset Register(MockScheduler scheduler)
+        {
+            lock (sync)
+            {
+                schedulers.Add(scheduler);
+                return now + scheduler.Interval;
+            }
+        }
+
+        private bool TryGetNextScheduler(DateTimeOffset deadline, out MockScheduler scheduler)
+        {
+            lock(sync)
+            {
+                scheduler = schedulers.OrderBy(s => s.NextInvocation).FirstOrDefault();
+                if (scheduler == null) return false;
+                return scheduler.NextInvocation <= deadline;
+            }
+        }
+
+        sealed class MockScheduler : Scheduler
+        {
+            private readonly MockClock owner;
+
+            public MockScheduler(MockClock owner)
+            {
+                this.owner = owner;
+            }
+
+            private CancellationTokenSource token;
+            private Func<CancellationToken, Task> scheduledAction;
+
+            public TimeSpan Interval { get; private set; }
+            public DateTimeOffset NextInvocation { get; private set; }
+
+            public void Start(TimeSpan interval, Action action)
+            {
+                Start(interval, t =>
+                {
+                    if (t.IsCancellationRequested) return;
+                    action();
+                });
+            }
+
+            public void Start(TimeSpan interval, Action<CancellationToken> action)
+            {
+                Start(interval, t =>
+                {
+                    action(t);
+                    return Task.FromResult(true);
+                });
+            }
+
+            public void Start(TimeSpan interval, Func<Task> action)
+            {
+                Start(interval, t =>
+                {
+                    if (!t.IsCancellationRequested) return Task.FromResult(true);
+                    return action();
+                });
+            }
+
+            public void Start(TimeSpan interval, Func<CancellationToken, Task> action)
+            {
+                if (interval == TimeSpan.Zero) throw new ArgumentException("Interval must be > 0 seconds", nameof(interval));
+                if (token != null) throw new InvalidOperationException("Scheduler is already started.");
+
+                token = new CancellationTokenSource();
+                scheduledAction = action;
+                Interval = interval;
+                NextInvocation = owner.Register(this);
+            }
+
+            public async Task<bool> TryRun()
+            {
+                if (token.IsCancellationRequested) return false;
+                Debug.Assert(owner.now == NextInvocation);
+                NextInvocation += Interval;
+                try
+                {
+                    await scheduledAction(token.Token).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    string message = "Error while executing action scheduler.";
+                    MetricsErrorHandler.Handle(ex, message);
+                    token.Cancel();
+                }
+                return !token.IsCancellationRequested;
+            }
+
+            public void Stop()
+            {
+                token?.Cancel();
+            }
+
+            public void Dispose()
+            {
+                if (this.token != null)
+                {
+                    this.token.Cancel();
+                    this.token.Dispose();
+                    token = null;
+                }
+            }
+        }
+    }
+}

--- a/Bluewire.Metrics.Specialised.UnitTests/Properties/AssemblyInfo.cs
+++ b/Bluewire.Metrics.Specialised.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Bluewire.Metrics.Specialised.UnitTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Bluewire.Metrics.Specialised.UnitTests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3536af7a-9b0a-4123-b5d2-ba582e6a3dc8")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Bluewire.Metrics.Specialised.UnitTests/RateMeterValueEqualityComparer.cs
+++ b/Bluewire.Metrics.Specialised.UnitTests/RateMeterValueEqualityComparer.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using Metrics.MetricData;
+
+namespace Bluewire.Metrics.Specialised.UnitTests
+{
+    public sealed class RateMeterValueEqualityComparer : IEqualityComparer<MeterValue>
+    {
+        public bool Equals(MeterValue x, MeterValue y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (ReferenceEquals(x, null)) return false;
+            if (ReferenceEquals(y, null)) return false;
+            if (x.GetType() != y.GetType()) return false;
+            return x.Count == y.Count
+                && x.MeanRate.Equals(y.MeanRate)
+                && x.OneMinuteRate.Equals(y.OneMinuteRate)
+                && x.FiveMinuteRate.Equals(y.FiveMinuteRate)
+                && x.FifteenMinuteRate.Equals(y.FifteenMinuteRate)
+                && x.RateUnit == y.RateUnit;
+        }
+
+        public int GetHashCode(MeterValue obj)
+        {
+            unchecked
+            {
+                var hashCode = obj.MeanRate.GetHashCode();
+                hashCode = (hashCode * 397) ^ obj.OneMinuteRate.GetHashCode();
+                hashCode = (hashCode * 397) ^ obj.FiveMinuteRate.GetHashCode();
+                hashCode = (hashCode * 397) ^ obj.FifteenMinuteRate.GetHashCode();
+                hashCode = (hashCode * 397) ^ (int)obj.RateUnit;
+                return hashCode;
+            }
+        }
+    }
+}

--- a/Bluewire.Metrics.Specialised.UnitTests/packages.config
+++ b/Bluewire.Metrics.Specialised.UnitTests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Metrics.NET" version="0.3.7" targetFramework="net461" />
+  <package id="NUnit" version="3.4.1" targetFramework="net461" />
+</packages>

--- a/Bluewire.Metrics.Specialised/Bluewire.Metrics.Specialised.csproj
+++ b/Bluewire.Metrics.Specialised/Bluewire.Metrics.Specialised.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{74DDE709-F8E9-4509-94D9-E721B67DC2B4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Bluewire.Metrics.Specialised</RootNamespace>
+    <AssemblyName>Bluewire.Metrics.Specialised</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Metrics, Version=0.3.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Metrics.NET.0.3.7\lib\net45\Metrics.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SpecialisedMetrics.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Bluewire.Metrics.Specialised.nuspec">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\MsBuild.NuGet.Pack.1.6.1\tools\MsBuild.NuGet.Pack.targets" Condition="Exists('..\packages\MsBuild.NuGet.Pack.1.6.1\tools\MsBuild.NuGet.Pack.targets')" />
+  <Target Name="EnsureMsBuildNuGetPackImported" BeforeTargets="BeforeBuild" Condition="'$(MsBuildNuGetPackImported)' == ''">
+    <Error Condition="!Exists('..\packages\MsBuild.NuGet.Pack.1.6.1\tools\MsBuild.NuGet.Pack.targets') And ('$(RunNuGetPack)' != '' And $(RunNuGetPack))" Text="You are trying to build with MsBuild.NuGet.Pack, but the MsBuild.NuGet.Pack.targets file is not available on this computer. This is probably because the MsBuild.NuGet.Pack package has not been committed to source control, or NuGet Package Restore is not enabled. Please enable NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\MsBuild.NuGet.Pack.1.6.1\tools\MsBuild.NuGet.Pack.targets') And ('$(RunNuGetPack)' != '' And $(RunNuGetPack))" Text="MsBuild.NuGet.Pack cannot be run because NuGet packages were restored prior to the build running, and the targets file was unavailable when the build started. Please build the project again to include these packages in the build. You may also need to make sure that your build server does not delete packages prior to each build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Bluewire.Metrics.Specialised/Bluewire.Metrics.Specialised.csproj
+++ b/Bluewire.Metrics.Specialised/Bluewire.Metrics.Specialised.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MeterRatioMeter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SpecialisedMetrics.cs" />
   </ItemGroup>

--- a/Bluewire.Metrics.Specialised/Bluewire.Metrics.Specialised.nuspec
+++ b/Bluewire.Metrics.Specialised/Bluewire.Metrics.Specialised.nuspec
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Bluewire.Metrics.Specialised</id>
+
+	<!-- When empty, this will be set at compile time to the [assembly:AssemblyProduct("")] attribute value -->
+    <title></title>
+
+	<!-- When empty, these will be set at compile time to either Thread.CurrentPrincipal.Identity.Name or Environment.UserName -->
+    <authors></authors>
+    <owners></owners>
+
+	<!-- Ignore, this will get updated at compile time -->
+    <version>1.0.0</version>
+
+	<!-- When empty, this will be set at compile time to the [assembly:AssemblyDescription("")] attribute value -->	
+    <summary></summary>
+	
+	<!-- When empty, this will be set at compile time to the [assembly:AssemblyTitle("")] attribute value -->
+    <description></description>
+    
+	<!-- Set this to false if you don't need to support a license -->
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+
+	<releaseNotes></releaseNotes>
+	<tags></tags>
+	
+    <dependencies>
+      <!-- Ignore, all referenced NuGet packages will be added here at compile time -->
+    </dependencies>
+
+    <frameworkAssemblies>
+      <!-- This will get populated at compile time with any System.* references in the project -->
+	  <!-- You will need to manually add any non-System.* assemblies here -->
+    </frameworkAssemblies>
+  </metadata>
+  <files>
+	<!-- This will automatically add the binary output of this project at compile time.
+	It will inject a file element like the following:		
+    <file src="**\Bluewire.Metrics.Specialised.*" target="lib/[targetFramework]" exclude="Bluewire.Metrics.Specialised.*.CodeAnalysisLog.xml;Bluewire.Metrics.Specialised.*.lastcodeanalysissucceeded;*Test*.*" />
+	The targetFramework value will be determined by the target framework of the project
+	-->
+
+	<!-- Add any additional files here manually -->
+  </files>
+</package>

--- a/Bluewire.Metrics.Specialised/Bluewire.Metrics.Specialised.v3.ncrunchproject
+++ b/Bluewire.Metrics.Specialised/Bluewire.Metrics.Specialised.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/Bluewire.Metrics.Specialised/MeterRatioMeter.cs
+++ b/Bluewire.Metrics.Specialised/MeterRatioMeter.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Metrics;
+using Metrics.Core;
+using Metrics.MetricData;
+
+namespace Bluewire.Metrics.Specialised
+{
+    /// <summary>
+    /// Represents the ratio of two meters, expressing the numerator relative to the denominator.
+    /// </summary>
+    /// <remarks>
+    /// The numerator defines the Count, and SetItem percentages and names.
+    /// Whenever the denominator is zero, the numerator is ignored entirely and information is NaN
+    /// or absent.
+    /// Named numerator marks without any corresponding named denominator marks are ignored, and
+    /// vice versa.
+    /// Mean and interval-based values are determined by simple division.
+    /// </remarks>
+    public class MeterRatioMeter : MeterImplementation
+    {
+        private readonly Meter numerator;
+        private readonly Meter denominator;
+
+        public MeterRatioMeter(Meter numerator, Meter denominator)
+        {
+            this.numerator = numerator;
+            this.denominator = denominator;
+        }
+
+        public MeterValue Value => GetValue();
+
+        public MeterValue GetValue(bool resetMetric = false)
+        {
+            var numeratorValue = ValueReader.GetCurrentValue(numerator);
+            var denominatorValue = ValueReader.GetCurrentValue(denominator);
+            return CreateMeterValue(numeratorValue, denominatorValue);
+        }
+
+        private static readonly MeterValue.SetItem[] EmptyItems = new MeterValue.SetItem[0];
+
+        private static MeterValue.SetItem CreateSetItem(MeterValue.SetItem numeratorItem, MeterValue.SetItem denominatorItem)
+        {
+            return new MeterValue.SetItem(
+                numeratorItem.Item,
+                numeratorItem.Percent,
+                CreateMeterValue(numeratorItem.Value, denominatorItem.Value)
+                );
+        }
+
+        private static MeterValue CreateMeterValue(MeterValue numeratorValue, MeterValue denominatorValue)
+        {
+            if (denominatorValue.Count == 0)
+            {
+                // With no marks on the denominator, return NaN to indicate 'no data' instead of
+                // dividing by zero and getting infinities. This is because an alerting system may
+                // look for a threshold being exceeded, and if a numerator mark happens to come in
+                // first then we will briefly report a value vastly in excess of the threshold.
+                return new MeterValue(
+                    numeratorValue.Count,
+                    double.NaN,
+                    double.NaN,
+                    double.NaN,
+                    double.NaN,
+                    numeratorValue.RateUnit,
+                    EmptyItems
+                );
+            }
+            return new MeterValue(
+                numeratorValue.Count,
+                numeratorValue.MeanRate / denominatorValue.MeanRate,
+                numeratorValue.OneMinuteRate / denominatorValue.OneMinuteRate,
+                numeratorValue.FiveMinuteRate / denominatorValue.FiveMinuteRate,
+                numeratorValue.FifteenMinuteRate / denominatorValue.FifteenMinuteRate,
+                numeratorValue.RateUnit,
+                MergeItems(numeratorValue.Items, denominatorValue.Items)
+            );
+        }
+
+        private static MeterValue.SetItem[] MergeItems(IList<MeterValue.SetItem> numerators, IList<MeterValue.SetItem> denominators)
+        {
+            if (denominators.Count == 0) return EmptyItems;
+            if (numerators.Count == 0) return EmptyItems;
+
+            var items = new MeterValue.SetItem[denominators.Count];
+            var index = numerators.ToDictionary(n => n.Item);
+            for (var i = 0; i < denominators.Count; i++)
+            {
+                MeterValue.SetItem numeratorItem;
+                if (index.TryGetValue(denominators[i].Item, out numeratorItem))
+                {
+                    items[i] = CreateSetItem(numeratorItem, denominators[i]);
+                }
+            }
+            return items;
+        }
+
+        void ResetableMetric.Reset() { throw new NotSupportedException(); }
+        void Meter.Mark() { throw new NotSupportedException(); }
+        void Meter.Mark(string item) { throw new NotSupportedException(); }
+        void Meter.Mark(long count) { throw new NotSupportedException(); }
+        void Meter.Mark(string item, long count) { throw new NotSupportedException(); }
+    }
+}

--- a/Bluewire.Metrics.Specialised/Properties/AssemblyInfo.cs
+++ b/Bluewire.Metrics.Specialised/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Bluewire.Metrics.Specialised")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Bluewire.Metrics.Specialised")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("74dde709-f8e9-4509-94d9-e721b67dc2b4")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Bluewire.Metrics.Specialised/SpecialisedMetrics.cs
+++ b/Bluewire.Metrics.Specialised/SpecialisedMetrics.cs
@@ -1,0 +1,8 @@
+﻿using Metrics;
+
+namespace Bluewire.Metrics.Specialised
+{
+    public static class SpecialisedMetrics
+    {
+    }
+}

--- a/Bluewire.Metrics.Specialised/SpecialisedMetrics.cs
+++ b/Bluewire.Metrics.Specialised/SpecialisedMetrics.cs
@@ -4,5 +4,18 @@ namespace Bluewire.Metrics.Specialised
 {
     public static class SpecialisedMetrics
     {
+        /// <summary>
+        /// Ratio of two meters, including named items and 1-, 5- and 15-minute means.
+        /// </summary>
+        /// <remarks>
+        /// This is intended for monitoring producer/consumer systems, recording the ratio of consumption
+        /// to production: the producer is dominant and we do not record consumed items which were not
+        /// produced (or more accurately, were produced in a previous 'session' and timing info is
+        /// unavailable).
+        /// </remarks>
+        public static Meter MeterRatioMeter(this MetricsContext context, string name, Unit unit, Meter numerator, Meter denominator)
+        {
+            return context.Advanced.Meter(name, unit, () => new MeterRatioMeter(numerator, denominator));
+        }
     }
 }

--- a/Bluewire.Metrics.Specialised/packages.config
+++ b/Bluewire.Metrics.Specialised/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Metrics.NET" version="0.3.7" targetFramework="net461" />
+  <package id="MsBuild.NuGet.Pack" version="1.6.1" targetFramework="net461" developmentDependency="true" />
+</packages>

--- a/Build.props
+++ b/Build.props
@@ -5,9 +5,11 @@
 
         <!-- Full list of NuGet package projects -->
         <NugetProjects Include="Bluewire.MetricsAdapter\Bluewire.MetricsAdapter.csproj" />
+        <NugetProjects Include="Bluewire.Metrics.Specialised\Bluewire.Metrics.Specialised.csproj" />
 
         <!-- Full list of NUnit test projects -->
         <NUnitProjects Include="Bluewire.MetricsAdapter.UnitTests\Bluewire.MetricsAdapter.UnitTests.csproj" />
+        <NUnitProjects Include="Bluewire.Metrics.Specialised.UnitTests\Bluewire.Metrics.Specialised.UnitTests.csproj" />
         
         <SemVerProjects Include="@(NugetProjects)" />
     </ItemGroup>

--- a/Metrics.sln
+++ b/Metrics.sln
@@ -13,6 +13,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bluewire.MetricsAdapter.Uni
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SolutionPackages", "SolutionPackages\SolutionPackages.csproj", "{F7E0A333-63E9-465A-A4B2-837ACD02E78F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bluewire.Metrics.Specialised", "Bluewire.Metrics.Specialised\Bluewire.Metrics.Specialised.csproj", "{74DDE709-F8E9-4509-94D9-E721B67DC2B4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bluewire.Metrics.Specialised.UnitTests", "Bluewire.Metrics.Specialised.UnitTests\Bluewire.Metrics.Specialised.UnitTests.csproj", "{3536AF7A-9B0A-4123-B5D2-BA582E6A3DC8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,6 +41,14 @@ Global
 		{BE06805E-2F56-40A6-B719-B67B3A03A8F8}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F7E0A333-63E9-465A-A4B2-837ACD02E78F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F7E0A333-63E9-465A-A4B2-837ACD02E78F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74DDE709-F8E9-4509-94D9-E721B67DC2B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74DDE709-F8E9-4509-94D9-E721B67DC2B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74DDE709-F8E9-4509-94D9-E721B67DC2B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74DDE709-F8E9-4509-94D9-E721B67DC2B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3536AF7A-9B0A-4123-B5D2-BA582E6A3DC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3536AF7A-9B0A-4123-B5D2-BA582E6A3DC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3536AF7A-9B0A-4123-B5D2-BA582E6A3DC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3536AF7A-9B0A-4123-B5D2-BA582E6A3DC8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Designed for monitoring a producer/consumer system, exposing the ratio of produced items to consumed. The producer is 'dominant' in that items which were not recorded as produced are not relevant to the metric.