### PR TITLE
Permit the key sanitisation character to be specified

### DIFF
--- a/ReshapeMetrics/MetricsUnrollingTransformer.cs
+++ b/ReshapeMetrics/MetricsUnrollingTransformer.cs
@@ -33,8 +33,8 @@ namespace ReshapeMetrics
         private readonly Regex rxQuestionableCharacters = new Regex(@"\W+");
         private string GetKeyString(string name)
         {
-            if (!SanitiseKeys) return name;
-            return rxQuestionableCharacters.Replace(name, "_");
+            if (SanitiseKeysCharacter == null) return name;
+            return rxQuestionableCharacters.Replace(name, new string(SanitiseKeysCharacter.Value, 1));
         }
 
         private object TransformCounter(JsonCounter counter)
@@ -81,6 +81,6 @@ namespace ReshapeMetrics
             };
         }
 
-        public bool SanitiseKeys { get; set; }
+        public char? SanitiseKeysCharacter { get; set; }
     }
 }

--- a/ReshapeMetrics/Program.cs
+++ b/ReshapeMetrics/Program.cs
@@ -22,7 +22,7 @@ namespace ReshapeMetrics
                 { "o|output=", "Output directory", o => arguments.OutputDirectory = o },
                 { "p|pretty|pretty-print|indent", "Generate readable, indented JSON instead of compacting it.", o => arguments.PrettyPrint = true },
                 { "a|archives|unwrap-archives", "Don't generate subdirectories for ZIP files in the output folder. Output all files directly.", o => arguments.UnwrapArchives = true },
-                { "s|sanitise", "When unrolling arrays into dictionaries, squash questionable characters to underscores.", o => arguments.SanitiseKeys = true },
+                { "s|sanitise:", "When unrolling arrays into dictionaries, squash questionable characters to the specified character. Default: _", (char? o) => arguments.SanitiseKeysCharacter = o ?? '_' },
             };
             var session = new ConsoleSession<Arguments>(arguments, options);
             session.ExtendedUsageDetails = @"
@@ -62,7 +62,7 @@ be ignored. Warnings will be written to STDERR.
             if (!arguments.ArgumentList.Any()) return 1; // Nothing to do?
 
             var outputDescriptor = GetOutput(arguments.OutputDirectory);
-            var transformer = new MetricsUnrollingTransformer { PrettyPrint = arguments.PrettyPrint, SanitiseKeys = arguments.SanitiseKeys };
+            var transformer = new MetricsUnrollingTransformer { PrettyPrint = arguments.PrettyPrint, SanitiseKeysCharacter = arguments.SanitiseKeysCharacter };
             var fileSystemVisitor = new FileSystemVisitor(new FileSystemVisitor.Options { MergeZipFilesWithFolder = arguments.UnwrapArchives });
 
 
@@ -115,7 +115,7 @@ be ignored. Warnings will be written to STDERR.
             public IList<string> ArgumentList { get; } = new List<string>();
             public bool PrettyPrint { get; set; }
             public bool UnwrapArchives { get; set; }
-            public bool SanitiseKeys { get; set; }
+            public char? SanitiseKeysCharacter { get; set; }
         }
     }
 }


### PR DESCRIPTION
The -s switch now takes an optional single-character parameter.