### PR TITLE
Fix handling of null numeric values

### DIFF
--- a/ReshapeMetrics/DoubleNaNJsonConverter.cs
+++ b/ReshapeMetrics/DoubleNaNJsonConverter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace ReshapeMetrics
+{
+    public class DoubleNaNAsNullJsonConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value == null || double.NaN.Equals(value))
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                writer.WriteValue((double)value);
+            }
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null) return double.NaN;
+            if (reader.TokenType == JsonToken.Undefined) return double.NaN;
+            if (reader.TokenType == JsonToken.Float) return (double)reader.Value;
+            if (reader.TokenType == JsonToken.String) return double.Parse(reader.Value.ToString());
+            throw new JsonReaderException($"DoubleNaNAsNullJsonConverter expected to find a number, but found a {reader.TokenType}");
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(double);
+        }
+    }
+}

--- a/ReshapeMetrics/MetricsTransformer.cs
+++ b/ReshapeMetrics/MetricsTransformer.cs
@@ -13,7 +13,11 @@ namespace ReshapeMetrics
             return new JsonSerializerSettings() {
                 NullValueHandling = NullValueHandling.Ignore,
                 DateFormatHandling = DateFormatHandling.IsoDateFormat,
-                Formatting = PrettyPrint ? Formatting.Indented : Formatting.None
+                Formatting = PrettyPrint ? Formatting.Indented : Formatting.None,
+                Converters =
+                {
+                    new DoubleNaNAsNullJsonConverter()
+                }
             };
         }
 
@@ -24,7 +28,7 @@ namespace ReshapeMetrics
 
         public void Transform(string content, IOutput output)
         {
-            var metrics = JsonConvert.DeserializeObject<JsonMetrics>(content);
+            var metrics = JsonConvert.DeserializeObject<JsonMetrics>(content, new DoubleNaNAsNullJsonConverter());
             var transformed = Transform(metrics);
             output.GetWriter().WriteLine(JsonConvert.SerializeObject(transformed, GetSerialiserSettings()));
         }

--- a/ReshapeMetrics/ReshapeMetrics.csproj
+++ b/ReshapeMetrics/ReshapeMetrics.csproj
@@ -65,6 +65,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DoubleNaNJsonConverter.cs" />
     <Compile Include="FileSystemVisitor.cs" />
     <Compile Include="ITransformer.cs" />
     <Compile Include="IOutput.cs" />


### PR DESCRIPTION
Metrics.NET serialises NaN values as null. Implement a JsonConverter to
roundtrip these properly.