### PR TITLE
Provide more useful standard functionality

### DIFF
--- a/Bluewire.MetricsAdapter/Bluewire.MetricsAdapter.csproj
+++ b/Bluewire.MetricsAdapter/Bluewire.MetricsAdapter.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -51,7 +52,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Configuration\MetricsConfigurationSection.cs" />
+    <Compile Include="Configuration\PeriodicLogConfigurationElement.cs" />
     <Compile Include="CustomMetricsReportExtensions.cs" />
+    <Compile Include="IEnvironmentEntrySource.cs" />
     <Compile Include="JsonMetricsReport.cs" />
     <Compile Include="Periodic\FilesystemLogJail.cs" />
     <Compile Include="Periodic\ILogArchiver.cs" />
@@ -64,7 +67,9 @@
     <Compile Include="Periodic\PerMinuteLogPolicy.cs" />
     <Compile Include="Periodic\PerSecondLogPolicy.cs" />
     <Compile Include="Periodic\RelativePathMapper.cs" />
+    <Compile Include="Periodic\ZipLogArchiver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StaticEnvironmentBlock.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Bluewire.MetricsAdapter.nuspec">

--- a/Bluewire.MetricsAdapter/Configuration/PeriodicLogConfigurationElement.cs
+++ b/Bluewire.MetricsAdapter/Configuration/PeriodicLogConfigurationElement.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Configuration;
+
+namespace Bluewire.MetricsAdapter.Configuration
+{
+    public class PeriodicLogConfigurationElement : ConfigurationElement
+    {
+        public string GetLogLocation(string baseDirectory, string defaultRelativePath)
+        {
+            if(!Enabled) return null;
+            if(String.IsNullOrWhiteSpace(Path)) return System.IO.Path.Combine(baseDirectory, defaultRelativePath);
+            return System.IO.Path.Combine(baseDirectory, Path);
+        }
+
+        [ConfigurationProperty("path")]
+        public string Path => (string)base["path"];
+        [ConfigurationProperty("enabled", DefaultValue = true)]
+        public bool Enabled => (bool)base["enabled"];
+        [ConfigurationProperty("daysToKeep")]
+        public int? DaysToKeep => (int?)base["daysToKeep"];
+    }
+}

--- a/Bluewire.MetricsAdapter/CustomMetricsReportExtensions.cs
+++ b/Bluewire.MetricsAdapter/CustomMetricsReportExtensions.cs
@@ -11,5 +11,11 @@ namespace Bluewire.MetricsAdapter
             var jail = new FilesystemLogJail(baseDirectory, archiver);
             return reports.WithReport(new JsonMetricsReport(new PeriodicLog(policy, jail), extraEnvironment), policy.LogInterval);
         }
+
+        public static MetricsReports WithJsonReport(this MetricsReports reports, string baseDirectory, PeriodicLogPolicy policy, ILogArchiver archiver, params IEnvironmentEntrySource[] extraEnvironment)
+        {
+            var jail = new FilesystemLogJail(baseDirectory, archiver);
+            return reports.WithReport(new JsonMetricsReport(new PeriodicLog(policy, jail), extraEnvironment), policy.LogInterval);
+        }
     }
 }

--- a/Bluewire.MetricsAdapter/IEnvironmentEntrySource.cs
+++ b/Bluewire.MetricsAdapter/IEnvironmentEntrySource.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using Metrics.MetricData;
+
+namespace Bluewire.MetricsAdapter
+{
+    public interface IEnvironmentEntrySource
+    {
+        IEnumerable<EnvironmentEntry> GetEntries(DateTimeOffset now);
+    }
+}

--- a/Bluewire.MetricsAdapter/JsonMetricsReport.cs
+++ b/Bluewire.MetricsAdapter/JsonMetricsReport.cs
@@ -15,9 +15,13 @@ namespace Bluewire.MetricsAdapter
     {
         private readonly ILog log = LogManager.GetLogger(typeof(JsonMetricsReport));
         private readonly PeriodicLog logImpl;
-        private readonly EnvironmentEntry[] extraEnvironment;
+        private readonly IEnvironmentEntrySource[] extraEnvironment;
 
-        public JsonMetricsReport(PeriodicLog log, params EnvironmentEntry[] extraEnvironment)
+        public JsonMetricsReport(PeriodicLog log, params EnvironmentEntry[] extraEnvironment) : this(log, new StaticEnvironmentBlock(extraEnvironment))
+        {
+        }
+
+        public JsonMetricsReport(PeriodicLog log, params IEnvironmentEntrySource[] extraEnvironment)
         {
             this.logImpl = log;
             this.extraEnvironment = extraEnvironment;
@@ -28,7 +32,7 @@ namespace Bluewire.MetricsAdapter
         private string GetReportContent(MetricsData metricsData, DateTimeOffset now)
         {
             return JsonBuilderV2.BuildJson(metricsData,
-                AppEnvironment.Current.Concat(extraEnvironment),
+                AppEnvironment.Current.Concat(extraEnvironment.SelectMany(e => e.GetEntries(now))),
                 Clock.Default,
                 PrettyPrintJson);
         }

--- a/Bluewire.MetricsAdapter/Periodic/ZipLogArchiver.cs
+++ b/Bluewire.MetricsAdapter/Periodic/ZipLogArchiver.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+
+namespace Bluewire.MetricsAdapter.Periodic
+{
+    public class ZipLogArchiver : ILogArchiver
+    {
+        public async Task Archive(Stream target, IEnumerable<LogArchivePart> parts)
+        {
+            using (var archive = new ZipArchive(target, ZipArchiveMode.Create, true))   // Stream is owned by the caller.
+            {
+                foreach (var part in parts)
+                {
+                    var entry = archive.CreateEntry(part.Name);
+                    using (var stream = entry.Open())
+                    {
+                        await part.WriteTo(stream);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Bluewire.MetricsAdapter/Properties/AssemblyInfo.cs
+++ b/Bluewire.MetricsAdapter/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyFileVersion("1.1.0")]

--- a/Bluewire.MetricsAdapter/StaticEnvironmentBlock.cs
+++ b/Bluewire.MetricsAdapter/StaticEnvironmentBlock.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using Metrics.MetricData;
+
+namespace Bluewire.MetricsAdapter
+{
+    public class StaticEnvironmentBlock : IEnvironmentEntrySource
+    {
+        private readonly EnvironmentEntry[] extraEnvironment;
+
+        public StaticEnvironmentBlock(params EnvironmentEntry[] extraEnvironment)
+        {
+            this.extraEnvironment = extraEnvironment;
+        }
+
+        public IEnumerable<EnvironmentEntry> GetEntries(DateTimeOffset now)
+        {
+            return extraEnvironment;
+        }
+    }
+}


### PR DESCRIPTION
It doesn't feel right to dictate a standard policy of 'per minute' and
'per hour' periodic logging, so the MetricsConfigurationSection probably
shouldn't be part of this project. But removing it would require a major
version bump, so simply make a copy of the useful
PeriodicLogConfigurationElement at the top level.

The System.IO.Compression namespace offers support for ZIP archives, so
provide a sane default archiver implementation.

Allow for 'dynamic' environment value strings. These are usually
expected to be static but there is some value in permitting them to be
generated on-the-fly, since not all 'metrics' are numeric. Until the
Metrics JSON format allows for general-purpose string fields in the
hierarchy, we can output namespaced environment entries instead.

Bluewire.MetricsAdapter: 1.0.0 -> 1.1.0