### PR TITLE
Fix child metric value mappings

### DIFF
--- a/Bluewire.Metrics.TimeSeries.UnitTests/DataPointFactoryTests.cs
+++ b/Bluewire.Metrics.TimeSeries.UnitTests/DataPointFactoryTests.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Bluewire.Metrics.TimeSeries.UnitTests
+{
+    [TestFixture]
+    public class DataPointFactoryTests
+    {
+        [Test]
+        public void RecordNameIsAppendedToPrototype()
+        {
+            var parent = DataPoint.Create();
+            parent.MeasurementPath = parent.MeasurementPath.Add("Parent");
+            var factory = new DataPointFactory(parent, DateTimeOffset.Now);
+
+            var result = factory.Create(new Record { Name = "Child" });
+
+            Assert.That(result.MeasurementPath, Is.EqualTo(ImmutableList<string>.Empty.Add("Parent").Add("Child")));
+        }
+
+        [Test]
+        public void RecordTagsAreMergedWithPrototype()
+        {
+            var parent = DataPoint.Create();
+            parent.Tags = parent.Tags.Add("ParentTag", "A");
+            var factory = new DataPointFactory(parent, DateTimeOffset.Now);
+
+            var result = factory.Create(new Record { Name = "Child", Tags = ImmutableDictionary<string, string>.Empty.Add("ChildTag", "B") });
+
+            Assert.That(result.Tags, Is.EqualTo(ImmutableDictionary<string, string>.Empty.Add("ParentTag", "A").Add("ChildTag", "B")));
+        }
+
+        [Test]
+        public void RecordValuesOverridePrototype()
+        {
+            var parent = DataPoint.Create();
+            parent.Values = parent.Values.Add("ParentValue", 1);
+            var factory = new DataPointFactory(parent, DateTimeOffset.Now);
+
+            var result = factory.Create(new Record { Name = "Child", Values = ImmutableDictionary<string, object>.Empty.Add("ChildValue", 2) });
+
+            Assert.That(result.Values, Is.EqualTo(ImmutableDictionary<string, object>.Empty.Add("ChildValue", 2)));
+        }
+
+        [Test]
+        public void RecordNullValuesAreIgnored()
+        {
+            var parent = DataPoint.Create();
+            parent.Values = parent.Values.Add("ParentValue", 1);
+            var factory = new DataPointFactory(parent, DateTimeOffset.Now);
+
+            var result = factory.Create(new Record { Name = "Child", Values = ImmutableDictionary<string, object>.Empty.Add("ChildValue", null) });
+
+            Assert.That(result.Values, Is.EqualTo(ImmutableDictionary<string, object>.Empty));
+        }
+
+        [Test]
+        public void ChildRecordNameIsNotAppendedToPrototype()
+        {
+            var parent = DataPoint.Create();
+            parent.MeasurementPath = parent.MeasurementPath.Add("Parent");
+            var factory = new DataPointFactory(parent, DateTimeOffset.Now);
+
+            var result = factory.CreateChild(new Record { Name = "Child" });
+
+            Assert.That(result.MeasurementPath, Is.EqualTo(ImmutableList<string>.Empty.Add("Parent")));
+        }
+
+        [Test]
+        public void ChildRecordNameIsAddedAsTag()
+        {
+            var parent = DataPoint.Create();
+            parent.MeasurementPath = parent.MeasurementPath.Add("Parent");
+            var factory = new DataPointFactory(parent, DateTimeOffset.Now);
+
+            var result = factory.CreateChild(new Record { Name = "Child" });
+
+            Assert.That(result.Tags, Is.EqualTo(ImmutableDictionary<string, string>.Empty.Add("child", "Child")));
+        }
+
+        [Test]
+        public void ChildRecordTagsAreMergedWithPrototype()
+        {
+            var parent = DataPoint.Create();
+            parent.Tags = parent.Tags.Add("ParentTag", "A");
+            var factory = new DataPointFactory(parent, DateTimeOffset.Now);
+
+            var result = factory.CreateChild(new Record { Name = "Child", Tags = ImmutableDictionary<string, string>.Empty.Add("ChildTag", "B") });
+
+            Assert.That(result.Tags, Is.EqualTo(ImmutableDictionary<string, string>.Empty.Add("ParentTag", "A").Add("child", "Child").Add("ChildTag", "B")));
+        }
+
+        [Test]
+        public void ChildRecordValuesOverridePrototype()
+        {
+            var parent = DataPoint.Create();
+            parent.Values = parent.Values.Add("ParentValue", 1);
+            var factory = new DataPointFactory(parent, DateTimeOffset.Now);
+
+            var result = factory.CreateChild(new Record { Name = "Child", Values = ImmutableDictionary<string, object>.Empty.Add("ChildValue", 2) });
+
+            Assert.That(result.Values, Is.EqualTo(ImmutableDictionary<string, object>.Empty.Add("ChildValue", 2)));
+        }
+
+        [Test]
+        public void ChildRecordNullValuesAreIgnored()
+        {
+            var parent = DataPoint.Create();
+            parent.Values = parent.Values.Add("ParentValue", 1);
+            var factory = new DataPointFactory(parent, DateTimeOffset.Now);
+
+            var result = factory.CreateChild(new Record { Name = "Child", Values = ImmutableDictionary<string, object>.Empty.Add("ChildValue", null) });
+
+            Assert.That(result.Values, Is.EqualTo(ImmutableDictionary<string, object>.Empty));
+        }
+    }
+}

--- a/Bluewire.Metrics.TimeSeries/AssemblyAttributes.cs
+++ b/Bluewire.Metrics.TimeSeries/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Bluewire.Metrics.TimeSeries.UnitTests")]

--- a/Bluewire.Metrics.TimeSeries/Bluewire.Metrics.TimeSeries.csproj
+++ b/Bluewire.Metrics.TimeSeries/Bluewire.Metrics.TimeSeries.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net46</TargetFrameworks>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>

--- a/Bluewire.Metrics.TimeSeries/DataPoint.cs
+++ b/Bluewire.Metrics.TimeSeries/DataPoint.cs
@@ -9,5 +9,13 @@ namespace Bluewire.Metrics.TimeSeries
         public ImmutableList<string> MeasurementPath { get; set; }
         public ImmutableDictionary<string, string> Tags { get; set; }
         public ImmutableDictionary<string, object> Values { get; set; }
+
+        public static DataPoint Create() =>
+            new DataPoint
+            {
+                MeasurementPath = ImmutableList<string>.Empty,
+                Tags = ImmutableDictionary<string, string>.Empty,
+                Values = ImmutableDictionary<string, object>.Empty
+            };
     }
 }

--- a/Bluewire.Metrics.TimeSeries/DataPointFactory.cs
+++ b/Bluewire.Metrics.TimeSeries/DataPointFactory.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Bluewire.Metrics.TimeSeries
+{
+    internal class DataPointFactory
+    {
+        private readonly DataPoint prototype;
+        private readonly DateTimeOffset contextTimestamp;
+
+        public DataPointFactory(DataPoint prototype, DateTimeOffset contextTimestamp)
+        {
+            this.prototype = prototype;
+            this.contextTimestamp = contextTimestamp;
+        }
+
+        public DataPoint Create(Record record)
+        {
+            return new DataPoint
+            {
+                Timestamp = contextTimestamp,
+                MeasurementPath = prototype.MeasurementPath.Add(record.Name),
+                Tags = prototype.Tags.AddRange(record.Tags?.Where(v => v.Value != null) ?? ImmutableDictionary<string, string>.Empty),
+                Values = ImmutableDictionary<string, object>.Empty.AddRange(record.Values?.Where(v => v.Value != null) ?? ImmutableDictionary<string, object>.Empty),
+            };
+        }
+
+        public DataPointFactory GetChildFactory(Record record)
+        {
+            var childPrototype = Create(new Record { Name = "Children", Tags = record.Tags, Values = record.Values });
+            return new DataPointFactory(childPrototype, contextTimestamp);
+        }
+
+        public DataPoint CreateChild(Record record)
+        {
+            return new DataPoint
+            {
+                Timestamp = contextTimestamp,
+                MeasurementPath = prototype.MeasurementPath,
+                Tags = prototype.Tags.Add("child", record.Name).AddRange(record.Tags ?? ImmutableDictionary<string, string>.Empty),
+                Values = ImmutableDictionary<string, object>.Empty.AddRange(record.Values?.Where(v => v.Value != null) ?? ImmutableDictionary<string, object>.Empty),
+            };
+        }
+    }
+}

--- a/Bluewire.Metrics.TimeSeries/DataPointMapper.cs
+++ b/Bluewire.Metrics.TimeSeries/DataPointMapper.cs
@@ -182,52 +182,5 @@ namespace Bluewire.Metrics.TimeSeries
             if (!tags.Any()) return ImmutableDictionary<string, string>.Empty;
             return ImmutableDictionary<string, string>.Empty.AddRange(tags.Select(t => new KeyValuePair<string, string>(string.Concat("tag_", t), "yes")));
         }
-
-        class DataPointFactory
-        {
-            private readonly DataPoint prototype;
-            private readonly DateTimeOffset contextTimestamp;
-
-            public DataPointFactory(DataPoint prototype, DateTimeOffset contextTimestamp)
-            {
-                this.prototype = prototype;
-                this.contextTimestamp = contextTimestamp;
-            }
-
-            public DataPoint Create(Record record)
-            {
-                return new DataPoint
-                {
-                    Timestamp = contextTimestamp,
-                    MeasurementPath = prototype.MeasurementPath.Add(record.Name),
-                    Tags = prototype.Tags.AddRange(record.Tags?.Where(v => v.Value != null) ?? ImmutableDictionary<string, string>.Empty),
-                    Values = prototype.Values.AddRange(record.Values?.Where(v => v.Value != null) ?? ImmutableDictionary<string, object>.Empty),
-                };
-            }
-
-            public DataPointFactory GetChildFactory(Record record)
-            {
-                var childPrototype = Create(new Record { Name = "Children", Tags = record.Tags, Values = record.Values });
-                return new DataPointFactory(childPrototype, contextTimestamp);
-            }
-
-            public DataPoint CreateChild(Record record)
-            {
-                return new DataPoint
-                {
-                    Timestamp = contextTimestamp,
-                    MeasurementPath = prototype.MeasurementPath,
-                    Tags = prototype.Tags.Add("child", record.Name).AddRange(record.Tags ?? ImmutableDictionary<string, string>.Empty),
-                    Values = prototype.Values,
-                };
-            }
-        }
-
-        struct Record
-        {
-            public string Name { get; set; }
-            public ImmutableDictionary<string, string> Tags { get; set; }
-            public ImmutableDictionary<string, object> Values { get; set; }
-        }
     }
 }

--- a/Bluewire.Metrics.TimeSeries/Record.cs
+++ b/Bluewire.Metrics.TimeSeries/Record.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Immutable;
+
+namespace Bluewire.Metrics.TimeSeries
+{
+    internal struct Record
+    {
+        public string Name { get; set; }
+        public ImmutableDictionary<string, string> Tags { get; set; }
+        public ImmutableDictionary<string, object> Values { get; set; }
+    }
+}


### PR DESCRIPTION
Use the record's values, not the prototype's. Add tests to cover this in
future.

refs D-2517

Bluewire.Metrics.TimeSeries: 1.0.0 -> 1.1.0