### PR TITLE
Include owning metric name in child path

### DIFF
--- a/Bluewire.Metrics.TimeSeries/Bluewire.Metrics.TimeSeries.csproj
+++ b/Bluewire.Metrics.TimeSeries/Bluewire.Metrics.TimeSeries.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net46</TargetFrameworks>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>

--- a/Bluewire.Metrics.TimeSeries/ChildDataPointFactory.cs
+++ b/Bluewire.Metrics.TimeSeries/ChildDataPointFactory.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Bluewire.Metrics.TimeSeries
+{
+    internal class ChildDataPointFactory
+    {
+        private readonly DataPoint prototype;
+        private readonly DateTimeOffset contextTimestamp;
+
+        public ChildDataPointFactory(DataPoint prototype, DateTimeOffset contextTimestamp)
+        {
+            this.prototype = prototype;
+            this.contextTimestamp = contextTimestamp;
+        }
+
+        public DataPoint CreateChild(Record record)
+        {
+            return new DataPoint
+            {
+                Timestamp = contextTimestamp,
+                MeasurementPath = prototype.MeasurementPath,
+                Tags = prototype.Tags.Add("child", record.Name).AddRange(record.Tags ?? ImmutableDictionary<string, string>.Empty),
+                Values = ImmutableDictionary<string, object>.Empty.AddRange(record.Values?.Where(v => v.Value != null) ?? ImmutableDictionary<string, object>.Empty),
+            };
+        }
+    }
+}

--- a/Bluewire.Metrics.TimeSeries/DataPointFactory.cs
+++ b/Bluewire.Metrics.TimeSeries/DataPointFactory.cs
@@ -26,21 +26,16 @@ namespace Bluewire.Metrics.TimeSeries
             };
         }
 
-        public DataPointFactory GetChildFactory(Record record)
+        public ChildDataPointFactory GetChildFactory(Record record)
         {
-            var childPrototype = Create(new Record { Name = "Children", Tags = record.Tags, Values = record.Values });
-            return new DataPointFactory(childPrototype, contextTimestamp);
-        }
-
-        public DataPoint CreateChild(Record record)
-        {
-            return new DataPoint
+            var childPrototype = new DataPoint
             {
                 Timestamp = contextTimestamp,
-                MeasurementPath = prototype.MeasurementPath,
-                Tags = prototype.Tags.Add("child", record.Name).AddRange(record.Tags ?? ImmutableDictionary<string, string>.Empty),
-                Values = ImmutableDictionary<string, object>.Empty.AddRange(record.Values?.Where(v => v.Value != null) ?? ImmutableDictionary<string, object>.Empty),
+                MeasurementPath = prototype.MeasurementPath.Add(record.Name).Add("Children"),
+                Tags = prototype.Tags.AddRange(record.Tags?.Where(v => v.Value != null) ?? ImmutableDictionary<string, string>.Empty),
+                Values = ImmutableDictionary<string, object>.Empty,
             };
+            return new ChildDataPointFactory(childPrototype, contextTimestamp);
         }
     }
 }


### PR DESCRIPTION
For example, use Lucene.Updates.Children rather than Lucene.Childen.