### PR TITLE
Try to create (and recreate) counters for the correct instance

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -9,6 +9,7 @@
         <NugetProjects Include="Bluewire.Metrics.Json\Bluewire.Metrics.Json.csproj" />
         <NugetProjects Include="Bluewire.Metrics.TimeSeries\Bluewire.Metrics.TimeSeries.csproj" />
         <NugetProjects Include="Bluewire.MetricsAdapter\Bluewire.MetricsAdapter.csproj" />
+        <NugetProjects Include="Metrics.IISApplicationCounters\Metrics.IISApplicationCounters.csproj" />
 
         <!-- Full list of NUnit test projects -->
         <NUnitProjects Include="**\*.UnitTests.csproj" />

--- a/Metrics.IISApplicationCounters/Metrics.IISApplicationCounters.csproj
+++ b/Metrics.IISApplicationCounters/Metrics.IISApplicationCounters.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net45</TargetFramework>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Metrics.NET" Version="0.5.5" />
+  </ItemGroup>
+
+</Project>

--- a/Metrics.IISApplicationCounters/MultiProcessAwarePerformanceCounters.cs
+++ b/Metrics.IISApplicationCounters/MultiProcessAwarePerformanceCounters.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Metrics.Core;
+using Metrics.Logging;
+
+namespace Metrics.IISApplicationCounters
+{
+    /// <summary>
+    /// Modified version of Metrics.NET's PerformanceCounters class. Determines the appropriate instance name to
+    /// pass when it's not the default, by searching for the instance associated with the current PID.
+    /// Also sort-of copes with instance names changing later, ie. when a process dies.
+    /// </summary>
+    public static class MultiProcessAwarePerformanceCounters
+    {
+        private static readonly ILog log = LogProvider.GetCurrentClassLogger();
+
+        private static readonly bool isMono = Type.GetType("Mono.Runtime") != null;
+
+        // Process counters.
+        private static PerformanceCounterCategoryDef Process { get; } = new PerformanceCounterCategoryDef("Process", "ID Process");
+
+        // CLR counters. Should all share instance names, since if one's defined the others are too?
+        private static PerformanceCounterCategoryDef Memory { get; } = new PerformanceCounterCategoryDef(".NET CLR Memory", "Process ID");
+        private static PerformanceCounterCategoryDef Exceptions { get; } = new PerformanceCounterCategoryDef(".NET CLR Exceptions", Memory.InstanceProvider);
+        private static PerformanceCounterCategoryDef LocksAndThreads { get; } = new PerformanceCounterCategoryDef(".NET CLR LocksAndThreads", Memory.InstanceProvider);
+
+        public static MetricsConfig WithMultiProcessAwareAppCounters(this MetricsConfig config, string context = PerformanceCountersConfigExtensions.DefaultApplicationCountersContext)
+        {
+            return config.WithConfigExtension((ctx, hs) => RegisterAppCounters(ctx.Context(context)));
+        }
+
+        public static void RegisterAppCounters(MetricsContext context)
+        {
+            var app = ProcessRef.GetCurrentProcess();
+
+            if (Process.TryGetInstanceName(app, out _))
+            {
+                Register(context, "Process CPU Usage", Unit.Percent, Process, "% Processor Time", app, derivate: v => v / Environment.ProcessorCount, tags: "cpu");
+                Register(context, "Process User Time", Unit.Percent, Process, "% User Time", app, derivate: v => v / Environment.ProcessorCount, tags: "cpu");
+                Register(context, "Process Privileged Time", Unit.Percent, Process, "% Privileged Time", app, derivate: v => v / Environment.ProcessorCount, tags: "cpu");
+
+                Register(context, "Private MBytes", Unit.MegaBytes, Process, "Private Bytes", app, derivate: v => v / (1024 * 1024.0), tags: "memory");
+                Register(context, "Working Set", Unit.MegaBytes, Process, "Working Set", app, derivate: v => v / (1024 * 1024.0), tags: "memory");
+
+                Register(context, "IO Data Operations/sec", Unit.Custom("IOPS"), Process, "IO Data Operations/sec", app, tags: "disk");
+                Register(context, "IO Other Operations/sec", Unit.Custom("IOPS"), Process, "IO Other Operations/sec", app, tags: "disk");
+            }
+
+            if (Memory.TryGetInstanceName(app, out _))
+            {
+                Register(context, "Mb in all Heaps", Unit.MegaBytes, Memory, "# Bytes in all Heaps", app, v => v / (1024 * 1024.0), tags: "memory");
+                Register(context, "Gen 0 heap size", Unit.MegaBytes, Memory, "Gen 0 heap size", app, v => v / (1024 * 1024.0), tags: "memory");
+                Register(context, "Gen 1 heap size", Unit.MegaBytes, Memory, "Gen 1 heap size", app, v => v / (1024 * 1024.0), tags: "memory");
+                Register(context, "Gen 2 heap size", Unit.MegaBytes, Memory, "Gen 2 heap size", app, v => v / (1024 * 1024.0), tags: "memory");
+                Register(context, "Large Object Heap size", Unit.MegaBytes, Memory, "Large Object Heap size", app, v => v / (1024 * 1024.0), tags: "memory");
+                Register(context, "Allocated Bytes/second", Unit.KiloBytes, Memory, "Allocated Bytes/sec", app, v => v / 1024.0, tags: "memory");
+
+                Register(context, "Time in GC", Unit.Custom("%"), Memory, "% Time in GC", app, tags: "memory");
+                Register(context, "Pinned Objects", Unit.Custom("Objects"), Memory, "# of Pinned Objects", app, tags: "memory");
+            }
+
+            if (Exceptions.TryGetInstanceName(app, out _))
+            {
+                Register(context, "Total Exceptions", Unit.Custom("Exceptions"), Exceptions, "# of Exceps Thrown", app, tags: "exceptions");
+                Register(context, "Exceptions Thrown / Sec", Unit.Custom("Exceptions"), Exceptions, "# of Exceps Thrown / Sec", app, tags: "exceptions");
+                Register(context, "Except Filters / Sec", Unit.Custom("Filters"), Exceptions, "# of Filters / Sec", app, tags: "exceptions");
+                Register(context, "Finallys / Sec", Unit.Custom("Finallys"), Exceptions, "# of Finallys / Sec", app, tags: "exceptions");
+                Register(context, "Throw to Catch Depth / Sec", Unit.Custom("Stack Frames"), Exceptions, "Throw to Catch Depth / Sec", app, tags: "exceptions");
+            }
+
+            if (LocksAndThreads.TryGetInstanceName(app, out _))
+            {
+                Register(context, "Logical Threads", Unit.Threads, LocksAndThreads, "# of current logical Threads", app, tags: "threads");
+                Register(context, "Physical Threads", Unit.Threads, LocksAndThreads, "# of current physical Threads", app, tags: "threads");
+                Register(context, "Contention Rate / Sec", Unit.Custom("Attempts"), LocksAndThreads, "Contention Rate / Sec", app, tags: "threads");
+                Register(context, "Total Contentions", Unit.Custom("Attempts"), LocksAndThreads, "Total # of Contentions", app, tags: "threads");
+                Register(context, "Queue Length / sec", Unit.Threads, LocksAndThreads, "Queue Length / sec", app, tags: "threads");
+            }
+            RegisterThreadPoolGauges(context);
+        }
+
+        internal static void RegisterThreadPoolGauges(MetricsContext context)
+        {
+            context.Gauge("Thread Pool Available Threads", () => { ThreadPool.GetAvailableThreads(out var threads, out _); return threads; }, Unit.Threads, tags: "threads");
+            context.Gauge("Thread Pool Available Completion Ports", () => { ThreadPool.GetAvailableThreads(out _, out var ports); return ports; }, Unit.Custom("Ports"), tags: "threads");
+
+            context.Gauge("Thread Pool Min Threads", () => { ThreadPool.GetMinThreads(out var threads, out _); return threads; }, Unit.Threads, tags: "threads");
+            context.Gauge("Thread Pool Min Completion Ports", () => { ThreadPool.GetMinThreads(out _, out var ports); return ports; }, Unit.Custom("Ports"), tags: "threads");
+
+            context.Gauge("Thread Pool Max Threads", () => { ThreadPool.GetMaxThreads(out var threads, out _); return threads; }, Unit.Threads, tags: "threads");
+            context.Gauge("Thread Pool Max Completion Ports", () => { ThreadPool.GetMaxThreads(out _, out var ports); return ports; }, Unit.Custom("Ports"), tags: "threads");
+
+            var currentProcess = System.Diagnostics.Process.GetCurrentProcess();
+            Func<TimeSpan> uptime = () => (DateTime.UtcNow - System.Diagnostics.Process.GetCurrentProcess().StartTime.ToUniversalTime());
+            context.Gauge(currentProcess.ProcessName + " Uptime Seconds", () => uptime().TotalSeconds, Unit.Custom("Seconds"));
+            context.Gauge(currentProcess.ProcessName + " Uptime Hours", () => uptime().TotalHours, Unit.Custom("Hours"));
+            context.Gauge(currentProcess.ProcessName + " Threads", () => System.Diagnostics.Process.GetCurrentProcess().Threads.Count, Unit.Threads, tags: "threads");
+        }
+
+        internal static void Register(MetricsContext context, string name, Unit unit,
+            PerformanceCounterCategoryDef category, string counter, ProcessRef process,
+            Func<double, double> derivate = null,
+            MetricTags tags = default(MetricTags))
+        {
+            try
+            {
+                WrappedRegister(context, name, unit, category, counter, process, derivate, tags);
+            }
+            catch (Exception x)
+            {
+                var message = $"Error reading performance counter data. {Util.GetHelpMessage()}";
+                MetricsErrorHandler.Handle(x, message);
+            }
+        }
+
+        private static void WrappedRegister(MetricsContext context, string name, Unit unit,
+            PerformanceCounterCategoryDef category, string counter, ProcessRef process,
+            Func<double, double> derivate = null,
+            MetricTags tags = default(MetricTags))
+        {
+            log.Debug(() => $"Registering performance counter [{counter}] in category [{category}] for process {process}");
+
+            if (PerformanceCounterCategory.Exists(category.Name))
+            {
+                if (PerformanceCounterCategory.CounterExists(counter, category.Name))
+                {
+                    var counterTags = new MetricTags(tags.Tags.Concat(new[] { "PerfCounter" }));
+                    if (derivate == null)
+                    {
+                        context.Advanced.Gauge(name, () => new ProcessPerformanceCounterGauge(category, counter, process), unit, counterTags);
+                    }
+                    else
+                    {
+                        context.Advanced.Gauge(name, () => new DerivedGauge(new ProcessPerformanceCounterGauge(category, counter, process), derivate), unit, counterTags);
+                    }
+                    return;
+                }
+            }
+
+            if (!isMono)
+            {
+                log.ErrorFormat("Performance counter does not exist [{0}] in category [{1}] for process {2}", counter, category, process);
+            }
+        }
+    }
+}

--- a/Metrics.IISApplicationCounters/PerformanceCounterCategoryDef.cs
+++ b/Metrics.IISApplicationCounters/PerformanceCounterCategoryDef.cs
@@ -1,0 +1,21 @@
+﻿namespace Metrics.IISApplicationCounters
+{
+    public class PerformanceCounterCategoryDef
+    {
+        public PerformanceCounterCategoryInstanceProvider InstanceProvider { get; }
+        public string Name { get; }
+
+        public PerformanceCounterCategoryDef(string category, PerformanceCounterCategoryInstanceProvider instanceProvider = null)
+        {
+            this.InstanceProvider = instanceProvider;
+            Name = category;
+        }
+
+        public PerformanceCounterCategoryDef(string category, string pidCounterName)
+            : this(category, new PerformanceCounterCategoryInstanceProvider(category, pidCounterName))
+        {
+        }
+
+        public bool TryGetInstanceName(ProcessRef process, out string instanceName) => InstanceProvider.TryGetInstanceName(process, out instanceName);
+    }
+}

--- a/Metrics.IISApplicationCounters/PerformanceCounterCategoryInstanceProvider.cs
+++ b/Metrics.IISApplicationCounters/PerformanceCounterCategoryInstanceProvider.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Metrics.IISApplicationCounters
+{
+    public class PerformanceCounterCategoryInstanceProvider
+    {
+        public string Category { get; }
+        public string PidCounterName { get; }
+
+        public PerformanceCounterCategoryInstanceProvider(string category, string pidCounterName)
+        {
+            Category = category;
+            this.PidCounterName = pidCounterName;
+        }
+
+        public bool TryGetInstanceName(ProcessRef process, out string instanceName)
+        {
+            instanceName = null;
+            foreach (var name in GetInstanceNames(process))
+            {
+                if (InstanceHasMatchingPid(name, process.Id))
+                {
+                    instanceName = name;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private IEnumerable<string> GetInstanceNames(ProcessRef process)
+        {
+            var category = new PerformanceCounterCategory(Category);
+            return category.GetInstanceNames()
+                .Where(n => n.StartsWith(process.Name))
+                // Instance name of our process should only ever 'decrease': #4 -> #3, etc.
+                // Note edge case at #10 -> #9, not handled here: 90% is good enough.
+                .OrderByDescending(n => n);
+        }
+
+        private bool InstanceHasMatchingPid(string instanceName, int pid)
+        {
+            if (PidCounterName == null) return true;    // Cannot determine.
+            using (var counter = new PerformanceCounter(Category, PidCounterName, instanceName, true))
+            {
+                return pid == (int)counter.RawValue;
+            }
+        }
+    }
+}

--- a/Metrics.IISApplicationCounters/PerformanceCounterFactory.cs
+++ b/Metrics.IISApplicationCounters/PerformanceCounterFactory.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Metrics.IISApplicationCounters
+{
+    public readonly struct PerformanceCounterFactory
+    {
+        private readonly PerformanceCounterCategoryDef category;
+        private readonly string counter;
+        private readonly ProcessRef process;
+
+        public PerformanceCounterFactory(PerformanceCounterCategoryDef category, string counter, ProcessRef process)
+        {
+            this.category = category;
+            this.counter = counter;
+            this.process = process;
+        }
+
+        /// <summary>
+        /// Tries a limited number of times to acquire a performance counter for the specified process, taking
+        /// into account Windows' bizarre instance-naming.
+        /// Returns null if the counter cannot be acquired.
+        /// </summary>
+        public async Task<PerformanceCounter> OpenPerformanceCounterAsync()
+        {
+            if (category == null) return null;
+            var tries = 3;
+            while (tries > 0)
+            {
+                tries--;
+                if (!TryGetInstanceName(out var instanceName)) return null;
+                try
+                {
+                    var performanceCounter = new PerformanceCounter(category.Name, counter, instanceName, true);
+                    // Check for race conditions: ensure that the instance name is still the same *after* we acquire the counter.
+                    if (!TryGetInstanceName(out var maybeChangedInstanceName)) return null;
+                    if (instanceName == maybeChangedInstanceName) return performanceCounter;
+                }
+                catch (Exception x)
+                {
+                    var message = $"Error reading performance counter data. {Util.GetHelpMessage()}";
+                    MetricsErrorHandler.Handle(x, message);
+                }
+                await Task.Yield();
+            }
+            return null;
+        }
+
+        internal bool TryGetInstanceName(out string instanceName)
+        {
+            instanceName = null;
+            try
+            {
+                if (category.TryGetInstanceName(process, out instanceName)) return true;
+                var message = $"Unable to determine instance name for this process {process}. {Util.GetHelpMessage()}";
+                MetricsErrorHandler.Handle(null, message);
+                return false;
+            }
+            catch (Exception ex)
+            {
+                var message = $"Unable to determine instance name for this process {process}. {Util.GetHelpMessage()}";
+                MetricsErrorHandler.Handle(ex, message);
+                return false;
+            }
+        }
+    }
+}

--- a/Metrics.IISApplicationCounters/ProcessPerformanceCounterGauge.cs
+++ b/Metrics.IISApplicationCounters/ProcessPerformanceCounterGauge.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Metrics.MetricData;
+
+namespace Metrics.IISApplicationCounters
+{
+    public class ProcessPerformanceCounterGauge : MetricValueProvider<double>
+    {
+        private Task<PerformanceCounter> performanceCounterTask;
+        private readonly PerformanceCounterFactory factory;
+        private readonly object syncObject = new object();
+
+        public ProcessPerformanceCounterGauge(PerformanceCounterCategoryDef category, string counter, ProcessRef process)
+        {
+            factory = new PerformanceCounterFactory(category, counter, process);
+            try
+            {
+                performanceCounterTask = factory.OpenPerformanceCounterAsync();
+            }
+            catch (Exception x)
+            {
+                var message = $"Error reading performance counter data. {Util.GetHelpMessage()}";
+                MetricsErrorHandler.Handle(x, message);
+            }
+        }
+
+        /// <summary>
+        /// Get the current counter instance, if available. Returns null if not.
+        /// </summary>
+        private PerformanceCounter Get()
+        {
+            var task = performanceCounterTask;
+            if (task == null) return null;    // Given up.
+            if (task.IsCompleted)
+            {
+                if (task.Status == TaskStatus.RanToCompletion) return task.Result;
+                lock (syncObject)
+                {
+                    if (task == performanceCounterTask)
+                    {
+                        performanceCounterTask = null;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private void Refresh()
+        {
+            lock (syncObject)
+            {
+                if (performanceCounterTask == null) return;    // Given up.
+                performanceCounterTask.ContinueWith(c => c.Dispose());
+                performanceCounterTask = factory.OpenPerformanceCounterAsync();
+            }
+        }
+
+        public double GetValue(bool resetMetric = false)
+        {
+            return this.Value;
+        }
+
+        public double Value
+        {
+            get
+            {
+                try
+                {
+                    return Get()?.NextValue() ?? double.NaN;
+                }
+                catch (Exception x)
+                {
+                    Refresh();
+                    var message = $"Error reading performance counter data. {Util.GetHelpMessage()}";
+                    MetricsErrorHandler.Handle(x, message);
+                    return double.NaN;
+                }
+            }
+        }
+    }
+}

--- a/Metrics.IISApplicationCounters/ProcessRef.cs
+++ b/Metrics.IISApplicationCounters/ProcessRef.cs
@@ -1,0 +1,24 @@
+﻿using System.Diagnostics;
+
+namespace Metrics.IISApplicationCounters
+{
+    public readonly struct ProcessRef
+    {
+        public static ProcessRef GetCurrentProcess()
+        {
+            var process = Process.GetCurrentProcess();
+            return new ProcessRef(process.ProcessName, process.Id);
+        }
+
+        public string Name { get; }
+        public int Id { get; }
+
+        public ProcessRef(string processName, int processId)
+        {
+            Name = processName;
+            Id = processId;
+        }
+
+        public override string ToString() => $"[{Name}, PID: {Id}]";
+    }
+}

--- a/Metrics.IISApplicationCounters/Util.cs
+++ b/Metrics.IISApplicationCounters/Util.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Security.Principal;
+
+namespace Metrics.IISApplicationCounters
+{
+    internal static class Util
+    {
+        internal static string GetHelpMessage() => $"The application is currently running as user {GetIdentity()}. Make sure the user has access to the performance counters. The user needs to be either Admin or belong to Performance Monitor user group.";
+
+        private static string GetIdentity()
+        {
+            try
+            {
+                return WindowsIdentity.GetCurrent().Name;
+            }
+            catch (Exception x)
+            {
+                return "[Unknown user | " + x.Message + " ]";
+            }
+        }
+    }
+}

--- a/Metrics.sln
+++ b/Metrics.sln
@@ -15,7 +15,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SolutionPackages", "Solutio
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bluewire.Metrics.TimeSeries", "Bluewire.Metrics.TimeSeries\Bluewire.Metrics.TimeSeries.csproj", "{ED2F78B5-23EB-4E2D-8A76-B5953B671656}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bluewire.Metrics.TimeSeries.UnitTests", "Bluewire.Metrics.TimeSeries.UnitTests\Bluewire.Metrics.TimeSeries.UnitTests.csproj", "{26FC192D-8431-40E9-BC67-05FA26D103E0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bluewire.Metrics.TimeSeries.UnitTests", "Bluewire.Metrics.TimeSeries.UnitTests\Bluewire.Metrics.TimeSeries.UnitTests.csproj", "{26FC192D-8431-40E9-BC67-05FA26D103E0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Metrics.IISApplicationCounters", "Metrics.IISApplicationCounters\Metrics.IISApplicationCounters.csproj", "{43BB0200-1D53-4426-A0B7-5ECB3F3358B6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -49,6 +51,10 @@ Global
 		{26FC192D-8431-40E9-BC67-05FA26D103E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{26FC192D-8431-40E9-BC67-05FA26D103E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{26FC192D-8431-40E9-BC67-05FA26D103E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43BB0200-1D53-4426-A0B7-5ECB3F3358B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43BB0200-1D53-4426-A0B7-5ECB3F3358B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43BB0200-1D53-4426-A0B7-5ECB3F3358B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43BB0200-1D53-4426-A0B7-5ECB3F3358B6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Performance counter instance names have no relation to PID. Determining
the correct instance name for a given process is fraught with peril and
race conditions, and instance names can change while the process runs.

This implements an alternative Metrics counter wrapper which tries to be
smart about instance names, looking for the one which corresponds to the
current PID and attempting to handle race conditions.

Assumes that the instance name for a given process is the same within a
group of counter categories, and that this applies to all counter
categories which we care about.